### PR TITLE
Update to ratatui 0.28

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ nom_locate = { version = "4", features = ["runtime-dispatch-simd"] }
 
 # generator
 ansi_term = { version = "0.12", optional = true }
-ratatui = { version = "0.26", optional = true, default-features = false }
+ratatui = { version = "0.28", optional = true, default-features = false }
 
 [dependencies.crossterm]
 version = "0.27"
@@ -39,7 +39,7 @@ default-features = false
 features = ["windows"]
 
 [dev-dependencies]
-ratatui = "0.26"
+ratatui = "0.28"
 crossterm = "0.27"
 ansi_term = "0.12"
 

--- a/examples/ratatui.rs
+++ b/examples/ratatui.rs
@@ -19,11 +19,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut terminal = Terminal::new(backend)?;
     terminal.hide_cursor()?;
 
-    let text = common::compile_file::<RatatuiTextGenerator, _>(args().nth(1).unwrap());
+    let text = common::compile_file::<RatatuiTextGenerator, _>(args().nth(1).expect("Expected a command line argument"));
 
     loop {
         terminal.draw(|frame| {
-            frame.render_widget(Paragraph::new(text.clone()), frame.size());
+            frame.render_widget(Paragraph::new(text.clone()), frame.area());
         })?;
 
         if let Event::Key(key) = crossterm::event::read()? {


### PR DESCRIPTION
I also replaced the deprecated `frame.size()` method with `frame.area()`
https://docs.rs/ratatui/latest/ratatui/struct.Frame.html#method.size

closes #2 